### PR TITLE
enforce eol=lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# enforce end of line encoding is LF, needed for CI to run correctly
+* text=auto eol=lf


### PR DESCRIPTION
The CI runner runs under Ubuntu. So a PR that created `books.json` under Windows would fail the CI because of the different line ending encodings.

This PR adds the file `.gitattributes` to enforce LR line endings for text files across the repo. I include all text files, and not just `books.json`, for future flexibility. (I have in mind to add a table within the readme from the json data, and then also check the readme as part of the CI.)

See also https://stackoverflow.com/questions/29435156/what-will-text-auto-eol-lf-in-gitattributes-do for some discussion about this git feature.