### PR TITLE
provide pgn2epd.py and adapt epd2pgn.py

### DIFF
--- a/pgn2epd.py
+++ b/pgn2epd.py
@@ -1,0 +1,41 @@
+import chess, chess.pgn, sys
+
+
+def pgn_to_epd(bookname):
+    epds = set()
+    fens = []
+    duplicates = []
+    count = 0
+    pgn = open(bookname)
+    while True:
+        game = chess.pgn.read_game(pgn)
+        if game is None:
+            break
+        count += 1
+        board = game.board()
+        for move in game.mainline_moves():
+            board.push(move)
+        epd = board.epd()  # ignore move counters when checking for duplicates
+        if epd in epds:
+            duplicates.append(count)
+        else:
+            epds.add(epd)
+        fens.append(board.fen())
+
+    if duplicates:
+        dstr = ",".join([str(g) for g in duplicates])
+        print(f"Warning: The following games lead to a duplicated exit: {dstr}.")
+
+    epdname = bookname.replace(".pgn", ".epd")
+    with open(epdname, "w") as f:
+        for fen in fens:
+            f.write(fen + "\n")
+    print(f"Wrote the converted book to {epdname}.")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2 and sys.argv[1].endswith(".pgn"):
+        pgn_to_epd(sys.argv[1])
+    else:
+        print(f"Usage: python {sys.argv[0]} <book.pgn>")
+        print("\nConverts a .pgn into an .epd book, keeping the order intact.")


### PR DESCRIPTION
This PR provides the script `pgn2epd.py` to convert `.pgn` books into `.epd` books. If duplicates are found, the user is given a corresponding warning.

We also adapt the existing `epd2pgn.py` to match the new script. Most importantly, the exits are no longer shuffled. (If users want to shuffle the exits, they can easily do so with `shuf foo.epd` before conversion.) In addition, the user is given a warning if a duplicate exit is discovered. To make this detection robust, the found FENs are parsed through python-chess to check for incorrect ep squares.

I think it is good to have both conversion scripts, and have them behave in a consistent way.

As a follow up, I may propose to remove some duplicated `.epd` books that are hardly used, as they can now be created on the fly if necessary.

PS: I also changed `1/2-1/2` to `*` in the `epd2pgn.py` script, to save some characters. That new format is standard, and I tested it successfully with fastchess.