### PR TITLE
add an initial fast CI run

### DIFF
--- a/.github/workflows/check_json_and_readme.yml
+++ b/.github/workflows/check_json_and_readme.yml
@@ -19,6 +19,16 @@ jobs:
       - name: install deps
         run: pip install chess
 
+      - name: run update_json.py (fast)
+        run: python update_json.py
+
+      - name: verify books.json (fast)
+        run: |
+          git diff --quiet --exit-code books.json || {
+            git --no-pager diff --no-color books.json
+            exit 1
+          }
+
       - name: run update_json.py
         run: rm -f books.json && python update_json.py
 

--- a/update_json.py
+++ b/update_json.py
@@ -3,6 +3,7 @@ import base64, chess, chess.pgn, hashlib, io, json, os, subprocess, zipfile
 json_file = "books.json"
 
 """ Run 'python update_json.py' to update the meta data stored in books.json.
+    Make sure to run 'git add' for new books _before_ running this script.
     Remove books.json if all the information should be recomputed from scratch.
 """
 


### PR DESCRIPTION
Implements a suggestion by @vdbergh.

We also add a comment in `update_json.py` to help book authors.

To summarize the CI actions:
* we first run `python update_json.py` without deleting `books.json` to quickly flag missing books or wrong sri's
* we then run `python update_json.py` after deleting `books.json` , so that all the meta data is computed afresh (this prevents accidental changes to the non-sri fields passing through unnoticed)
* we then run `python update_readme.py` to ensure integrity of the readme file
