### PR TITLE
[bugfix] ignore line endings when computing the sri

### DIFF
--- a/books.json
+++ b/books.json
@@ -13,7 +13,7 @@
         "black": 0,
         "min_depth": 4,
         "max_depth": 4,
-        "sri": "uV7ni0IjOAJnufjffVXYdeRvWX8k6KHH9qdj1f4tq8qGu/yLiTkajlHNRNt/oqAm"
+        "sri": "0Lr258yUv8tjfjtBM+nYrfhqItfI08WhixuLJExp4x0nsoUD5okbopwtx3UgrXsw"
     },
     "3moves_FRC.epd": {
         "total": 126113,
@@ -21,7 +21,7 @@
         "black": 0,
         "min_depth": 6,
         "max_depth": 6,
-        "sri": "B2Xtc8K9x1JhiforTh/j2dXiChZ9prXlwfsUgXwVkBZxEKb18EipzUBDItGVPFYv"
+        "sri": "LwTw2fQ0ZvCcR5lCHpvdKfbBFBkHEVyNVI1Yo45XnjM8c64yhsHHr0qjVPQGYiv0"
     },
     "4mvs_+90_+99.epd": {
         "total": 635,
@@ -29,7 +29,7 @@
         "black": 0,
         "min_depth": 8,
         "max_depth": 8,
-        "sri": "OrJ/nVsQciFTB0ozXshiXDDZ56WE5zKdr0cMsrSwhdT23MbiEqFNQ2xRm+v894Kp"
+        "sri": "SdC+/KCNqLOeMN0ldi6lEy8/9clpU6RzzIHmQhPW/vH84P6s2iqBr+uQUcKdivsY"
     },
     "6mvs_+90_+99.epd": {
         "total": 2933,
@@ -37,7 +37,7 @@
         "black": 0,
         "min_depth": 12,
         "max_depth": 12,
-        "sri": "fh8G9o6r6OJVONNxYBT1ZnGQevIhsV0LjdJPaa63pAtANYDPKbnd/K0ED2TVE6tt"
+        "sri": "xqOZ1U6JybYRfiCMfiZGHB2xP087Xcgd1NPlrWBCtd3DZi2O2Zph9XKzqIbUpU8s"
     },
     "8moves_v3.pgn": {
         "total": 34700,
@@ -45,7 +45,7 @@
         "black": 0,
         "min_depth": 16,
         "max_depth": 16,
-        "sri": "drf0LyW+HCqpwYvn3pE5+KHnG3WQofGC18vtRV1kjnQvrRu8rB+RUFN0NsGDAq1/"
+        "sri": "hnlrIvi1xbnTt8z3AM2LW87YUCNsrcTTjqlAUBRf80SUCx9Zaq2hlntlimtoEBIn"
     },
     "8mvs_+90_+99.epd": {
         "total": 8533,
@@ -53,7 +53,7 @@
         "black": 0,
         "min_depth": 16,
         "max_depth": 16,
-        "sri": "JAMC9KuG50fdNK2R+YV7SNKk+bpCyWA39NhLy+BGUo7GYXsGpJFF6Lr1dtSf+h15"
+        "sri": "eBqHadeotTSDz8rlxCjNja1TnRAtRcBDNlJWZq1Nck53DE1I3Es4CpR4K3nMQC27"
     },
     "8mvs_big_+80_+109.epd": {
         "total": 25857,
@@ -61,7 +61,7 @@
         "black": 0,
         "min_depth": 16,
         "max_depth": 16,
-        "sri": "isz6ubFj5Mo2PLlLLg+xtehW3+SF7/o6unHIHCzWHXx/vGgbFBOgtsa99+okvTzq"
+        "sri": "DWy48t+1SiSqM1JYUnwRP8ImBXfqF6WCOuxMhAp6idL1NAaw035dkHh/gQrDJuy8"
     },
     "bjbraams_chessdb_198350_lines.pgn": {
         "total": 198350,
@@ -101,7 +101,7 @@
         "black": 0,
         "min_depth": 28,
         "max_depth": 28,
-        "sri": "vgltOu0cfBCRBUt5E+Buk9P7E/n2LlEnwIOp8dG/q1DkJzgKH/mivWg1klt/ZmA7"
+        "sri": "0m/3NJefSiRh0WavDpp7y7wc03SE3tetDoFVTl4LPZ3nODBHOvYVQxC9mnHqP02Q"
     },
     "endgames.epd": {
         "total": 157846,
@@ -125,7 +125,7 @@
         "black": 0,
         "min_depth": null,
         "max_depth": null,
-        "sri": "BZKpMZvausaf1O0LXbcobG9RWdMXK0F/QQhRwiDpvZFgD3IuuqNRknZqC2FvgRsI"
+        "sri": "JoTl0t3+UauWxrba8y1eGxgx1x/nhw4t87KGWePRJxV2/aKJjbX1N6IM1dxlxlZg"
     },
     "noob_2moves.epd": {
         "total": 7314,
@@ -245,7 +245,7 @@
         "black": 0,
         "min_depth": 16,
         "max_depth": 16,
-        "sri": "dVMubbSulaPBZv9vmhh1a80fsCA9MLcN51XGqWFNW00Z+agLbYHhDQURBuUfhh9H"
+        "sri": "o2okHsxSaded/t0tUvqOIYAV8T2hG22PjV8v7/ryFaNYUTAjFxJ6o1M714bevkn0"
     },
     "UHO_XXL_+0.80_+1.09.pgn": {
         "total": 261028,
@@ -253,7 +253,7 @@
         "black": 0,
         "min_depth": 16,
         "max_depth": 16,
-        "sri": "E9QyYfzbn/s03ueDeKq+poqBpLwwYY6g79R5JXtFj1FxUsYB5j1qNg3KTgqCdgqs"
+        "sri": "lkmgYtbuR0hD2rN0KOym8FYBK551JSdXLPrKMnxgqAm5DSVR+ymbMVhYOSjEEHFw"
     },
     "UHO_XXL_+0.90_+1.19.pgn": {
         "total": 223070,
@@ -261,7 +261,7 @@
         "black": 0,
         "min_depth": 16,
         "max_depth": 16,
-        "sri": "xnpY+GaWf/8UBpguZRTL6yimA4gixGGSlT/bT6Sg+Su/BD0Zz+SSYO9dAvfH59qc"
+        "sri": "eiO1EFbWBpGP9Y5nhXkuzy0kGGz17PeHx+D3VNp8W7X1LXTOzsrAyzJKYZIseYVU"
     },
     "UHO_XXL_+1.00_+1.29.pgn": {
         "total": 186098,
@@ -269,7 +269,7 @@
         "black": 0,
         "min_depth": 16,
         "max_depth": 16,
-        "sri": "hL7QVZcnVWTYtPEy3/ZV4Mtt5lHQfPO3NjPqSV1S8/wcS5p2zLFZ4c0sBK7RDmXJ"
+        "sri": "R5rw57QhSrh9nvThnXyp2EFVuba9EoM3uIWz8x+BmqKnf2h9oKD9oqi0i0RSnxe5"
     },
     "UHO_XXL_2022_+100_+129.pgn": {
         "total": 284035,
@@ -277,7 +277,7 @@
         "black": 0,
         "min_depth": 16,
         "max_depth": 16,
-        "sri": "Zm7JkVvV0w2fThQ1KqEHtW9A1Gep3H2Cy2lp4bYmBrQlg3b8Z1dNp5luI4rI4SdN"
+        "sri": "s+xxJB1Eej8x+piXtwLhe3spn1Kd5cfxQXlu3Qi+dh2AuaprZsqIxYffUAWVVvgm"
     },
     "UHO_XXL_2022_+110_+139.pgn": {
         "total": 253847,
@@ -285,7 +285,7 @@
         "black": 0,
         "min_depth": 16,
         "max_depth": 16,
-        "sri": "ukD2bRPycwOniwdivzAGOx50DB4jEJsFSqHydxt0iXVZ7rfeLanHjEi4hpayqkLh"
+        "sri": "wrsxfJKm4PHnPPEL0ChbCvYotLtu+lefKXBrgwZwMNtIJ9Ndk4klitTVtRg0SUj6"
     },
     "UHO_XXL_2022_+120_+149.pgn": {
         "total": 226629,
@@ -293,6 +293,6 @@
         "black": 0,
         "min_depth": 16,
         "max_depth": 16,
-        "sri": "Xpqvh2yrr5ynVHcrPn4PSl/WMVRE8G5UnRrcP1l6jsMtUUoPdo9xEPtzmOHiI6ga"
+        "sri": "7ZJfiwwWKy37hLeLu39i1SPHk5Bi/Q6BmdLpS6nFELbiDsBmGxxcPw+WNeFOGiWK"
     }
 }

--- a/update_json.py
+++ b/update_json.py
@@ -9,12 +9,15 @@ json_file = "books.json"
 
 def get_stats_and_sri(compressedbook, old_stats):
     content_bytes = None
+    book = compressedbook
     if compressedbook.endswith(".zip"):
         book, _, _ = compressedbook.rpartition(".zip")
         with zipfile.ZipFile(compressedbook) as zip_file:
             content_bytes = zip_file.read(book)
     if content_bytes is None:
         return book, {}
+
+    content_bytes = content_bytes.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
 
     sri = base64.b64encode(hashlib.sha384(content_bytes).digest()).decode("utf8")
 


### PR DESCRIPTION
Fixes https://github.com/official-stockfish/fishtest/issues/2393.

In master we compute the sri for the binary contents of the unzipped archive. This PR first unifies the newline encodings to ensure the same sri as computed by the fishtest worker.